### PR TITLE
Implement Fuubar#exception

### DIFF
--- a/lib/cucumber/formatter/fuubar.rb
+++ b/lib/cucumber/formatter/fuubar.rb
@@ -42,15 +42,19 @@ module Cucumber
         return if @in_background || status == :skipped
         @state = :red if status == :failed
         if exception and [:failed, :undefined].include? status
-          @io.print "\e[K"
-          @issues_count += 1
-          @io.puts
-          @io.puts "#{@issues_count})"
-          print_exception(exception, status, 2)
-          @io.puts
-          @io.flush
+          self.exception(exception, status)
         end
         progress(status)
+      end
+      
+      def exception(exception, status)
+        @io.print "\e[K"
+        @issues_count += 1
+        @io.puts
+        @io.puts "#{@issues_count})"
+        print_exception(exception, status, 2)
+        @io.puts
+        @io.flush
       end
 
       def before_examples(examples)


### PR DESCRIPTION
AFAICT, if a Before() step raises an exception, it doesn't call after_step_result(), but just broadcasts to listeners implementing an 'exception' method.
Before this change, fuubar would show failed scenarios, but not tell you anything about why they failed.

What do you think?
