### PR TITLE
Use @options instead of @options.custom_profiles in print_stats

### DIFF
--- a/lib/cucumber/formatter/fuubar.rb
+++ b/lib/cucumber/formatter/fuubar.rb
@@ -79,7 +79,7 @@ module Cucumber
         end
 
         def print_summary(features)
-          print_stats(features, @options.custom_profiles)
+          print_stats(features, @options)
           print_snippets(@options)
           print_passing_wip(@options)
         end


### PR DESCRIPTION
This is a fix for this issue: https://github.com/martinciu/fuubar-cucumber/issues/7

It follows a change that Cucumber made here: https://github.com/cucumber/cucumber/commit/ee23daa0271a5caa43e42211ccd188e3a65a4102#lib/cucumber/formatter/console.rb
