### PR TITLE
Relax cucumber dependency

### DIFF
--- a/fuubar-cucumber.gemspec
+++ b/fuubar-cucumber.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
   
-  s.add_dependency 'cucumber', ["~> 1.0.2"]
+  s.add_dependency 'cucumber', [">= 1.0.2"]
   s.add_dependency 'ruby-progressbar', ["~> 0.0.10"]
   
 end


### PR DESCRIPTION
Cucumber has been bumped to 1.1.0, relax the dependency in the gemspec to make fuubar-cucumber work with the newer versions
