### PR TITLE
Conform to Cucumber 1.2.0 formatter API change

### DIFF
--- a/fuubar-cucumber.gemspec
+++ b/fuubar-cucumber.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
   
-  s.add_dependency 'cucumber', [">= 1.0.2"]
+  s.add_dependency 'cucumber', ["~> 1.2.0"]
   s.add_dependency 'ruby-progressbar', ["~> 0.0.10"]
   
 end

--- a/lib/cucumber/formatter/fuubar.rb
+++ b/lib/cucumber/formatter/fuubar.rb
@@ -38,7 +38,7 @@ module Cucumber
         @in_background = false
       end
 
-      def after_step_result(keyword, step_match, multiline_arg, status, exception, source_indent, background)
+      def after_step_result(keyword, step_match, multiline_arg, status, exception, source_indent, background, file_colon_line)
         return if @in_background || status == :skipped
         @state = :red if status == :failed
         if exception and [:failed, :undefined].include? status


### PR DESCRIPTION
Cucumber 1.2.0 changed their API, by changing the method signatures of the formatters.

This will update fuubar to match the new interface, thus not exploding in my face.
