### PR TITLE
Bump to latest ruby-progressbar

### DIFF
--- a/fuubar-cucumber.gemspec
+++ b/fuubar-cucumber.gemspec
@@ -15,5 +15,5 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_dependency 'cucumber', ["~> 1.2.0"]
-  s.add_dependency 'ruby-progressbar', ["~> 0.0.10"]
+  s.add_dependency 'ruby-progressbar', ["~> 0.11"]
 end


### PR DESCRIPTION
Use latest version so that Delorean mocking works properly. See

jfelchner/ruby-progressbar#16
