### PR TITLE
Make compatible with Cucumber 1.2.3's rename of step_mother to runtime

### DIFF
--- a/lib/cucumber/formatter/fuubar.rb
+++ b/lib/cucumber/formatter/fuubar.rb
@@ -9,15 +9,16 @@ module Cucumber
       include Console
       include Io
 
-      attr_reader :step_mother
+      attr_reader :runtime
+      alias_method :step_mother, :runtime
 
-      def initialize(step_mother, path_or_io, options)
-        @step_mother, @io, @options = step_mother, ensure_io(path_or_io, "fuubar"), options
+      def initialize(runtime, path_or_io, options)
+        @runtime, @io, @options = runtime, ensure_io(path_or_io, "fuubar"), options
         @step_count = @issues_count = 0
       end
 
       def after_features(features)
-        @state = :red if step_mother.scenarios(:failed).any?
+        @state = :red if runtime.scenarios(:failed).any?
         @io.puts
         @io.puts
         print_summary(features)


### PR DESCRIPTION
See cucumber/cucumber@f74a8dad3e8ff1b1e9fe7762369266817f229a8f

Also maintains backwards compatibility with previous Cucumber versions by aliasing `step_mother` to `runtime`.
