### PR TITLE
keep up with the latest ruby-progressbar

### DIFF
--- a/fuubar-cucumber.gemspec
+++ b/fuubar-cucumber.gemspec
@@ -15,5 +15,5 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_dependency 'cucumber', ["~> 1.3.0"]
-  s.add_dependency 'ruby-progressbar', ["~> 1.2"]
+  s.add_dependency 'ruby-progressbar', [">= 1.2"]
 end


### PR DESCRIPTION
ruby-progressbar is up to version 1.5.1, since the current version requires around 1.2, there maybe conflicts with other gems 
