### PR TITLE
Support for cucumber 3

### DIFF
--- a/fuubar-cucumber.gemspec
+++ b/fuubar-cucumber.gemspec
@@ -14,6 +14,6 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_dependency 'cucumber', ["~> 1.3.0"]
+  s.add_dependency 'cucumber', [">= 1", "< 4"]
   s.add_dependency 'ruby-progressbar', ["~> 1.2"]
 end

--- a/lib/cucumber/formatter/fuubar3.rb
+++ b/lib/cucumber/formatter/fuubar3.rb
@@ -1,0 +1,56 @@
+require 'cucumber/formatter/progress'
+require 'ruby-progressbar'
+
+module Cucumber
+  module Formatter
+    class Fuubar < Progress
+      def initialize(config)
+        super
+        config.on_event :test_run_started, &method(:test_run_started)
+      end
+
+      def test_run_started(event)
+        steps = event.test_cases.map(&:test_steps).flatten.reject(&method(:hook?))
+        @progress_bar = ProgressBar.create(:format => ' %c/%C |%w>%i| %e ', :total => steps.count, :output => @io)
+      end
+
+      def on_test_step_finished(event)
+        test_step = event.test_step
+        result = event.result.with_filtered_backtrace(Cucumber::Formatter::BacktraceFilter)
+        progress(result.to_sym) unless hook?(test_step)
+
+        return if hook?(test_step)
+        collect_snippet_data(test_step, result)
+        @pending_step_matches << @matches[test_step.source] if result.pending?
+        @failed_results << result if result.failed?
+      end
+
+      private
+
+      COLORS = { :green =>  "\e[32m", :yellow => "\e[33m", :red => "\e[31m" }
+
+      def state
+        @state ||= :green
+      end
+
+      def progress(status)
+        @state = :red if status == :failed
+        with_colors(COLORS[state]) { @progress_bar.progress += 1 }
+      end
+
+      def with_colors(color, &block)
+        @io.print color if colors_enabled?
+        yield
+        @io.print "\e[0m" if colors_enabled?
+      end
+
+      def colors_enabled?
+        Cucumber::Term::ANSIColor.coloring?
+      end
+      
+      def hook?(step)
+        HookQueryVisitor.new(step).hook?
+      end
+    end
+  end
+end

--- a/lib/fuubar-cucumber.rb
+++ b/lib/fuubar-cucumber.rb
@@ -1,10 +1,18 @@
-require 'cucumber/formatter/fuubar'
+module FuubarCucumber
+  def cucumber3?
+    defined?(::Cucumber) && ::Cucumber::VERSION >= '3'
+  end
 
-# Extend Cucumber's builtin formats, so that this
-# formatter can be used with --format fuubar
-require 'cucumber/cli/main'
+  module_function :cucumber3?
 
-Cucumber::Cli::Options::BUILTIN_FORMATS["fuubar"] = [
-  "Cucumber::Formatter::Fuubar",
-  "The instafailing Cucumber progress bar formatter"
-]
+  require "cucumber/formatter/fuubar#{cucumber3? ? '3' : ''}"
+
+  # Extend Cucumber's builtin formats, so that this
+  # formatter can be used with --format fuubar
+  require 'cucumber/cli/main'
+
+  Cucumber::Cli::Options::BUILTIN_FORMATS["fuubar"] = [
+    "Cucumber::Formatter::Fuubar",
+    "The instafailing Cucumber progress bar formatter"
+  ]
+end


### PR DESCRIPTION
Extends the [built in progress formatter](https://github.com/cucumber/cucumber-ruby/blob/v3.1.2/lib/cucumber/formatter/progress.rb) and uses the progress bar instead of dots.

I doubt it works with cucumber 2 since I think the test run started event name changed, but I'll leave that to someone else if they want to get that version working.

![AF96E594-81F5-4607-9C37-709876BC736A](https://user-images.githubusercontent.com/4854/54883148-63b95d80-4e30-11e9-8040-a520da2e8bd6.png)
